### PR TITLE
Fix: Only install Nix IDE inside the container, not on host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,12 @@
 	"build": {
 		// Path is relative to the devcontainer.json file.
 		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"jnoortheen.nix-ide"
+			]
+		}
 	}
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "jnoortheen.nix-ide",
         "ms-vscode-remote.remote-containers"
     ]
 }


### PR DESCRIPTION
The whole point of this repo is that the host does not have the tooling required for Nix IDE to function so it should only be installed inside the container and not recommended for install on the host.