### PR TITLE
Remove nix-daemon wrapper script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,25 +10,14 @@ RUN nix-env --install --attr \
         nixpkgs.alejandra \
         nixpkgs.nixfmt \
         nixpkgs.gnused \
-        nixpkgs.killall \
         nixpkgs.patchelf
-
-# Make some directories that we will use to assemble our compatability layer
-RUN mkdir -p /root/lib /root/bin
-
-COPY --chmod=755 LSPwrapper /root/bin/LSPwrapper
-
-# NixIDE takes it's "nix.serverPath" parameter as a full path, even with spaces, so we cannot pass arguments to the wrapper
-# to select what LSP to run.  We work around this by having different names for the wrapper and executing the appropriate
-# LSP based on the name the script is called as. There should be a symlink here for every LSP in the container.
-RUN ln -s /root/bin/LSPwrapper /root/bin/nixd && \
-    ln -s /root/bin/LSPwrapper /root/bin/nil
 
 # Luckily, vscode code-server has support for ELF patching the node binary, we will leverage that to make it work in Nix
 # If they ever remove this support, it's easy enough to just run patchelf outselves.  You can see how it works at
 # https://github.com/microsoft/vscode/blob/31ec1c528f3352405f329821df31b91e6deba824/resources/server/bin/code-server-linux.sh
 # We need an easy to reference location for the binaries and libraries we will need for the binary patch
-RUN ln -s $(nix-instantiate --eval-only --expr '(import <nixpkgs> {}).glibc.outPath'  | sed -e 's/"//g') /root/lib/glibc && \
+RUN mkdir -p /root/lib /root/bin && \
+    ln -s $(nix-instantiate --eval-only --expr '(import <nixpkgs> {}).glibc.outPath'  | sed -e 's/"//g') /root/lib/glibc && \
     ln -s $(nix-instantiate --eval-only --expr '(import <nixpkgs> {}).libgcc.lib.outPath'  | sed -e 's/"//g') /root/lib/libgcc && \
     ln -s $(which patchelf) /root/bin/patchelf
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,8 @@
 {
     "nix.enableLanguageServer": true,
-    // Both nixd and nil work
-    // You need to call the versions inside /root/bin/ to ensure that nix-daemon is also started
-    // Only uncomment one of the below lines
-    // "nix.serverPath": "/root/bin/nil",
-    "nix.serverPath": "/root/bin/nixd",
+    // Both nixd and nil are pre-installed, only uncomment one of the below lines
+    // "nix.serverPath": "nil",
+    "nix.serverPath": "nixd",
     "nix.hiddenLanguageServerErrors": [
         "textDocument/definition",
     ],

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ It includes the following functionality:
 - A VSCode settings file that has the bare minimum needed to get Nix IDE functional
   - Pre-configured to use nixfmt for code formatting, but alejandra is available in the container if you prefer it
   - Formatting on save is not enabled in the settings.json, so your global preferences should be respected there.  You can uncomment the line in .vscode/settings.json if you want it
-- A wrapper script to run the nixd LSP that ensures that nix-daemon is running (nixd needs nix-daemon for code completion functionality)
 - The container is the official [nixos/nix container](https://hub.docker.com/r/nixos/nix) so you can open a VSCode Terminal and use all of your familiar nix-env, nix-shell, etc commands
   - NOTE: The container is NOT NixOS, it is a minimal container with Nix package management.  You can still use this to develop your NixOS configurations, but don't expect tooling like nixos-rebuild and such, it's a container, not a full operating system.
 


### PR DESCRIPTION
Not sure why it wasn't working before, but it appears that nix-daemon is not needed for nixd or nil, which greatly simplifies things!